### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/commit-healthchecks.yml
+++ b/.github/workflows/commit-healthchecks.yml
@@ -1,4 +1,6 @@
 name: Commit Healthchecks
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/a-binkley/personal-website/security/code-scanning/2](https://github.com/a-binkley/personal-website/security/code-scanning/2)

To fix the problem, explicitly add a `permissions` block to the workflow. The safest, minimal starting point is to set `permissions: contents: read` at the workflow level (the root), so all jobs inherit it. This grants only read access to repository contents, which is all that is needed for tasks like linting or running tests. There is no evidence from the workflow that any `write` level permission is needed for other resources. Add the `permissions` block directly below the workflow `name` and above `on:` in `.github/workflows/commit-healthchecks.yml`. No other changes or additional imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
